### PR TITLE
Link directly to the svelte compiler options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,7 +115,7 @@ The default configuration should work for most people but for anyone who would l
 
 This can be done though a `svelte.config.js` file, `.svelterc` file or `svelte` field in `package.json`.
 
-For documentation on which parameters you can set and use look at the official [svelte docs](https://github.com/sveltejs/svelte).
+For documentation on which parameters you can set and use look at the official [svelte docs](https://svelte.dev/docs#svelte_compile).
 
 ```Javascript
 // Used by svelte.compile


### PR DESCRIPTION
Modify the svelte parameter link to point directly at the appropriate section in the svelte docs, instead of at the svelte repository itself.